### PR TITLE
Separated jest config and fixed logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  coverageReporters: [
+    'json',
+    'lcov',
+    'text-summary'
+  ],
+  moduleFileExtensions: [
+    'js',
+    'jsx',
+    'scss'
+  ],
+  modulePaths: [
+    './src'
+  ],
+  setupFiles: [
+    '<rootDir>/config/jest/setup.js'
+  ],
+  transform: {
+    '^.+\\.(js|jsx)$': '<rootDir>/node_modules/babel-jest',
+    '^.+\\.css$': '<rootDir>/config/jest/cssTransform.js',
+    '^(?!.*\\.(js|jsx|css|json)$)': '<rootDir>/config/jest/fileTransform.js'
+  },
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,32 +13,6 @@
     "start": "webpack-dev-server --config examples/webpack.config.live.babel.js",
     "test": "npm run lint && npm run coverage"
   },
-  "jest": {
-    "coverageReporters": [
-      "json",
-      "lcov",
-      "text-summary"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "scss"
-    ],
-    "modulePaths": [
-      "./src"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setup.js"
-    ],
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-    },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ]
-  },
   "dependencies": {
     "react": "^16.6.0"
   },

--- a/src/Breakpoint/breakpoint-util.js
+++ b/src/Breakpoint/breakpoint-util.js
@@ -92,11 +92,14 @@ const B = new BreakpointUtil();
 export default B;
 
 export const setDefaultBreakpoints = (customBreakpoints) => {
-  if (!customBreakpoints || !customBreakpoints.length) {
-    throw new Error('setDefaultBreakpoints error: Breakpoints should be an array of objects');
+  if (!customBreakpoints || typeof customBreakpoints !== 'object' || !(customBreakpoints instanceof Array)) {
+    throw new Error('setDefaultBreakpoints error: Breakpoints should be an array');
   }
 
   customBreakpoints.forEach((obj) => {
+    if (!obj || typeof obj !== 'object') {
+      throw new Error('setDefaultBreakpoints error: Breakpoints should be an array of objects');
+    }
     if (Object.keys(obj).length !== 1) {
       throw new Error('setDefaultBreakpoints error: Each breakpoint object should have only one key');
     }

--- a/src/Breakpoint/breakpoint-util.test.js
+++ b/src/Breakpoint/breakpoint-util.test.js
@@ -13,24 +13,25 @@ describe('Breakpoint Util', () => {
   });
 
   it('throw error while setting breakpoints - not an array', () => {
-    // this wont work
-    // expect(setDefaultBreakpoints(null)).toThrow();
-    try {
-      setDefaultBreakpoints(null);
-    } catch (e) {
-      expect(e.message).toEqual(
-        'setDefaultBreakpoints error: Breakpoints should be an array of objects'
-      );
-    }
+    expect(() => setDefaultBreakpoints(null)).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
+    expect(() => setDefaultBreakpoints("hello")).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
+    expect(() => setDefaultBreakpoints({})).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
+    expect(() => setDefaultBreakpoints(undefined)).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
+    expect(() => setDefaultBreakpoints(1.0)).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
+    expect(() => setDefaultBreakpoints(true)).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
+    expect(() => setDefaultBreakpoints(false)).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array$/);
   });
 
+  it('throw error while setting breakpoints - not an array of objects', () => {
+    expect(() => setDefaultBreakpoints([null])).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array of objects$/);
+    expect(() => setDefaultBreakpoints(["hello"])).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array of objects$/);
+    expect(() => setDefaultBreakpoints([undefined])).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array of objects$/);
+    expect(() => setDefaultBreakpoints([1.0])).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array of objects$/);
+    expect(() => setDefaultBreakpoints([true, false])).toThrowError(/^setDefaultBreakpoints error: Breakpoints should be an array of objects$/);
+  });
+  
   it('throw error while setting breakpoints - wrong object format', () => {
-    try {
-      setDefaultBreakpoints([{ a: 1010, b: 1010 }]);
-    } catch (e) {
-      expect(e.message).toEqual(
-        'setDefaultBreakpoints error: Each breakpoint object should have only one key'
-      );
-    }
+    expect(() => setDefaultBreakpoints([{}])).toThrowError(/^setDefaultBreakpoints error: Each breakpoint object should have only one key$/);
+    expect(() => setDefaultBreakpoints([{ a: 1010, b: 1010 }])).toThrowError(/^setDefaultBreakpoints error: Each breakpoint object should have only one key$/);
   });
 });


### PR DESCRIPTION
Separating out jest config from `package.json` and fixing `setDefaultBreakpoints` array checking issues.